### PR TITLE
Fix/generate-schedule

### DIFF
--- a/app/routes/schedule_config.py
+++ b/app/routes/schedule_config.py
@@ -1,5 +1,10 @@
 import random
-from flask import Blueprint, request, jsonify
+import time
+from datetime import datetime, timedelta, timezone
+
+from bson import ObjectId
+from flask import Blueprint, jsonify, request
+
 from app import mongo
 from app.utils.calculating_shift import (
     calculate_total_time_blocks,
@@ -10,8 +15,6 @@ from app.utils.calculating_shift import (
     shift_types,
     store_time_mapping_safely,
 )
-from bson import ObjectId
-from datetime import datetime, timedelta, timezone
 
 schedule_config_bp = Blueprint(
     "schedule_config", __name__, url_prefix="/api/schedule_config"
@@ -38,6 +41,20 @@ def validate_time_format(time_string):
         return True
     except ValueError:
         return False
+
+
+def generate_13_digit_uid_fixed():
+    """Generate a more unique 13-digit identifier."""
+    # Use time.time() for efficiency. Get milliseconds.
+    # Take the last 9 digits to ensure it changes rapidly and fits.
+    time_part = str(int(time.time() * 1000))[-9:]
+
+    # Get a 4-digit random number
+    random_part = str(random.randint(1000, 9999))
+
+    # Combine them to make a 13-digit number
+    uid = int(f"{time_part}{random_part}")
+    return uid
 
 
 def generate_13_digit_uid():

--- a/app/routes/scheduling.py
+++ b/app/routes/scheduling.py
@@ -264,3 +264,31 @@ def generate_and_save_schedule():
     }
     return jsonify(response), 200
 
+
+@scheduling_bp.route("/get_schedules", methods=["GET"])
+def get_schedules():
+    # Required headers (same contract you had)
+    company = request.headers.get("COMPANY")
+    department = request.headers.get("DEPARTMENT")
+    if not company or not department:
+        return jsonify(
+            {
+                "success": False,
+                "message": "Missing required headers 'COMPANY' and 'DEPARTMENT'",
+            }
+        ), 400
+
+    # Optional filter via query param: ?schedule_uuid=abc or ?schedule_uuid=a,b,c
+    schedule_uuid_param = request.args.get("schedule_uuid", "").strip()
+
+    filter_doc = {"COMPANY": company, "DEPARTMENT": department}
+    if schedule_uuid_param:
+        uuids = [u.strip() for u in schedule_uuid_param.split(",") if u.strip()]
+        if len(uuids) == 1:
+            filter_doc["schedule_uuid"] = uuids[0]
+        elif uuids:
+            filter_doc["schedule_uuid"] = {"$in": uuids}
+
+    # Same projection, same response shape
+    cursor = mongo.db.schedules.find(filter_doc, {"_id": 0})
+    return jsonify({"success": True, "schedules": list(cursor)}), 200

--- a/app/routes/scheduling.py
+++ b/app/routes/scheduling.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
 
+import uuid
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from flask import Blueprint, current_app, jsonify, request
 from werkzeug.exceptions import BadRequest, UnsupportedMediaType
 
+from app import mongo
 from app.config import Config
 from app.models.error_response import UpstreamError
+from app.routes.schedule_config import (
+    convert_request_to_mongo_format,
+    generate_13_digit_uid_fixed,
+    validate_schedule_config,
+)
 from app.services.engine_client.client_request import (
     run_engine_client,  # your function that raises UpstreamError
 )
 from app.services.engine_client.validate_and_format_schedule import (
     validate_and_format_schedule,
+)
+from app.utils.calculating_shift import (
+    calculate_total_time_blocks,
+    generate_time_unit_map,
+    get_time_unit_from_datetime_and_time,
+    inverse_map,
+    store_time_mapping_safely,
 )
 
 # from app.validators.engine import validate_engine_response
@@ -50,8 +65,115 @@ def handle_unsupported_media(e: UnsupportedMediaType):
     ), 415
 
 
+
+def create_schedule_config(
+    schedule_uuid: str, schedule_period: dict[str, str], company: str, department: str
+):
+    start_date_str, end_date_str, start_time_str, end_time_str = (
+        schedule_period["start_date"],
+        schedule_period["end_date"],
+        schedule_period["start_time"],
+        schedule_period["end_time"],
+    )
+
+    start_dt, end_dt = (
+        datetime.strptime(f"{start_date_str} {start_time_str}", "%Y-%m-%d %H:%M"),
+        datetime.strptime(f"{end_date_str} {end_time_str}", "%Y-%m-%d %H:%M"),
+    )
+
+    # Generate mappings based on start and end planning horizon
+    time_block_horus = 0.5
+    total_time_blocks = calculate_total_time_blocks(start_dt, end_dt, time_block_horus)
+    time_unit_map = generate_time_unit_map(start_dt, end_dt, time_block_horus)
+    datetime_to_unit_map = inverse_map(time_unit_map)
+    store_time_mapping_safely(
+        schedule_uuid, time_unit_map, datetime_to_unit_map, department, company
+    )
+
+    shift_obj = mongo.db.configs.find(
+        {"DEPARTMENT": department, "COMPANY": company}, {"SHIFT_TYPE": 1, "_id": 0}
+    ).next()
+    shifts = shift_obj.get("SHIFT_TYPE", [])
+
+    mongo_shifts = []
+    for shift in shifts:
+        shift_type = shift["type"]
+        roles_applied_to = shift["roles_applied_to"]
+        days_applied_to = shift["days_applied_to"]
+
+        start_tbs, end_tbs = _get_shift_start_end_tbs(
+            shift, start_dt, end_dt, datetime_to_unit_map
+        )
+
+        shift_uid = generate_13_digit_uid_fixed()
+        mongo_shift = {
+            "shift_uid": shift_uid,
+            "start_time_block": start_tbs,
+            "type": shift_type,
+            "end_time_block": end_tbs,
+            "roles_applied_to": roles_applied_to,
+            "days_applied_to": days_applied_to,
+        }
+        print(f"Mongo_SHIFT: {mongo_shift}")
+        mongo_shifts.append(mongo_shift)
+
+    # Build the final MongoDB document
+    mongo_doc = {
+        "schedule_uuid": schedule_uuid,
+        "scheduling_period": {
+            "start_date": start_date_str,
+            "end_date": end_date_str,
+            "start_time": start_time_str,
+            "end_time": end_time_str,
+            "number_of_days": schedule_period["number_of_days"],
+            "total_time_block": total_time_blocks,
+        },
+        "COMPANY": company,
+        "DEPARTMENT": department,
+        "SHIFT": mongo_shifts,
+    }
+
+    return mongo_doc
+
+
+def _get_shift_start_end_tbs(
+    shift: dict[str, Any],
+    start_datetime: datetime,
+    end_datetime: datetime,
+    datetime_to_unit_map: dict[datetime, int],
+):
+    start_time, end_time = shift["start_time"], shift["end_time"]
+    start_time_dt, end_time_dt = (
+        datetime.strptime(start_time, "%H:%M"),
+        datetime.strptime(end_time, "%H:%M"),
+    )
+
+    days_applied_to = shift["days_applied_to"]
+
+    start_tbs, end_tbs = [], []
+    current_datetime = start_datetime
+    # Iterate throw all days to generate timeblocks
+    while current_datetime <= end_datetime:
+        if current_datetime.weekday() in days_applied_to:
+            shift_start_dt = datetime.combine(
+                current_datetime.date(), start_time_dt.time()
+            )
+            shift_end_dt = datetime.combine(current_datetime.date(), end_time_dt.time())
+
+            # check if shift_end_dt < shift_start_dt, if so, account for cross day end time
+            if shift_end_dt <= shift_start_dt:
+                shift_end_dt += timedelta(days=1)
+
+            start_tbs.append(datetime_to_unit_map[shift_start_dt])
+            end_tbs.append(datetime_to_unit_map[shift_end_dt])
+
+        print(f"currentdt: {current_datetime}")
+        current_datetime += timedelta(days=1)
+
+    return start_tbs, end_tbs
+
 @scheduling_bp.route("/generate", methods=["POST"])
-def generate_schedule():
+def generate_and_save_schedule():
     """
     ### Generate schedule
     Validates request JSON, calls the engine upstream, verifies the engine response contract,
@@ -75,10 +197,43 @@ def generate_schedule():
     token = Config.ENGINE_TOKEN
     timeout = Config.ENGINE_TIMEOUT
 
-    # UpstreamErrors raised will be handled by handler above
+    # Manipulate shift information to format for engine
+    schedule_uuid = str(uuid.uuid4())
+    try:
+        mongo_doc = create_schedule_config(
+            schedule_uuid,
+            payload["SCHEDULING_PERIOD"],
+            payload["COMPANY"],
+            payload["DEPARTMENT"],
+        )
+    except Exception as e:
+        return jsonify(
+            {
+                "success": False,
+                "message": "Error converting request data",
+                "error": str(e),
+            }
+        ), 400
+
+    # Add timestamps
+    mongo_doc["updated_at"] = datetime.now(timezone.utc)
+    mongo_doc["created_at"] = datetime.now(timezone.utc)
+
+    # Updated schedule config info if needed
+    query_filter = {"DEPARTMENT": payload["DEPARTMENT"], "COMPANY": payload["COMPANY"]}
+    update_doc = {"$set": {**mongo_doc}}
+    result = mongo.db.schedule_config.update_one(query_filter, update_doc, upsert=True)
+
+    if result.upserted_id:
+        print(f"Updated schedule configuration. Upserted id: {result.upserted_id}")
+    else:
+        print("No document to update!")
+
+    # Add schedule_uuid into payload for engine referencing
+    payload["schedule_uuid"] = schedule_uuid
     schedule: Any = run_engine_client(url, payload, token=token, timeout=timeout)
 
-    # enforce for now while engine is still unstabl
+    # enforce for now while engine is still unstable
     errs = validate_and_format_schedule(schedule)
     if errs:
         current_app.logger.warning("InvalidEngineResponse", extra={"errors": errs})
@@ -92,6 +247,20 @@ def generate_schedule():
             }
         ), 502
 
-    return jsonify(
-        {"success": True, "message": "Schedule generated", "data": schedule}
-    ), 200
+    schedule_to_store = {
+        **schedule,
+        "schedule_uuid": schedule_uuid,
+        "COMPANY": payload["COMPANY"],
+        "DEPARTMENT": payload["DEPARTMENT"],
+    }
+    mongo.db.schedules.insert_one(schedule_to_store)
+
+    # pop storage _id from schedule, not needed as uuid is "entry_uuid"
+    schedule_to_store.pop("_id", None)
+    response = {
+        "success": True,
+        "message": "Schedule generated",
+        **schedule_to_store,
+    }
+    return jsonify(response), 200
+

--- a/app/utils/calculating_shift.py
+++ b/app/utils/calculating_shift.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from typing import Optional, Union
+
 from app import mongo
 
 shift_types = [
@@ -100,7 +101,7 @@ def sanitize_data(data):
         # Test JSON serialization to catch any other issues
         import json
         json.dumps(sanitized, default=str)
-        
+
         return sanitized
     except (TypeError, ValueError) as e:
         print(f"Data sanitization warning: {e}")
@@ -108,15 +109,19 @@ def sanitize_data(data):
         return {}
     
 
-def store_time_mapping_safely(uuid, time_unit_map, datetime_to_unit_map):
+def store_time_mapping_safely(
+    uuid, time_unit_map, datetime_to_unit_map, department: str, company: str
+):
     """
     Safely store time unit mappings in MongoDB without breaking or giving errors
-    
+
     Args:
         uuid: Unique identifier for the mapping configuration
         time_unit_map: Time unit mapping dictionary
         datetime_to_unit_map: Datetime to unit mapping dictionary
-    
+        department: Department name of the specific generated time_map
+        company: Company name of the specific generated time_map
+
     Returns:
         dict: Result containing success status and details
     """
@@ -134,41 +139,47 @@ def store_time_mapping_safely(uuid, time_unit_map, datetime_to_unit_map):
     safe_datetime_to_unit_map = sanitize_data(datetime_to_unit_map)
     # Prepare the update document
     update_doc = {
-        '$set': {
-            'time_unit_map': safe_time_unit_map,
-            'datetime_to_unit_map': safe_datetime_to_unit_map,
-            'created_at': datetime.utcnow().isoformat() if 'datetime' in globals() else "unknown",
-            'updated_at': datetime.utcnow().isoformat() if 'datetime' in globals() else "unknown"
+        "$set": {
+            "COMPANY": company,
+            "DEPARTMENT": department,
+            "time_unit_map": safe_time_unit_map,
+            "datetime_to_unit_map": safe_datetime_to_unit_map,
+            "created_at": datetime.utcnow().isoformat()
+            if "datetime" in globals()
+            else "unknown",
+            "updated_at": datetime.utcnow().isoformat()
+            if "datetime" in globals()
+            else "unknown",
         }
     }
-    
+
     # Try to perform the upsert operation
     try:
         result = mongo.db.mapping_config.update_one(
-            {'uuid': uuid},
-            update_doc,
-            upsert=True
+            {"uuid": uuid}, update_doc, upsert=True
         )
-        
+
         return {
-            'success': True,
-            'error': None,
-            'result': {
-                'matched_count': getattr(result, 'matched_count', 0),
-                'modified_count': getattr(result, 'modified_count', 0),
-                'upserted_id': str(result.upserted_id) if hasattr(result, 'upserted_id') and result.upserted_id else None,
-                'acknowledged': getattr(result, 'acknowledged', True)
-            }
+            "success": True,
+            "error": None,
+            "result": {
+                "matched_count": getattr(result, "matched_count", 0),
+                "modified_count": getattr(result, "modified_count", 0),
+                "upserted_id": str(result.upserted_id)
+                if hasattr(result, "upserted_id") and result.upserted_id
+                else None,
+                "acknowledged": getattr(result, "acknowledged", True),
+            },
         }
     except Exception as e:
         # If MongoDB operation fails, still return success to avoid breaking
         return {
-            'success': True,
-            'error': 'MongoDB operation bypassed',
-            'result': {
-                'matched_count': 0,
-                'modified_count': 0,
-                'upserted_id': None,
-                'acknowledged': False
-            }
+            "success": True,
+            "error": "MongoDB operation bypassed",
+            "result": {
+                "matched_count": 0,
+                "modified_count": 0,
+                "upserted_id": None,
+                "acknowledged": False,
+            },
         }

--- a/app/utils/calculating_shift.py
+++ b/app/utils/calculating_shift.py
@@ -110,7 +110,7 @@ def sanitize_data(data):
     
 
 def store_time_mapping_safely(
-    uuid, time_unit_map, datetime_to_unit_map, department: str, company: str
+    schedule_uuid, time_unit_map, datetime_to_unit_map, department: str, company: str
 ):
     """
     Safely store time unit mappings in MongoDB without breaking or giving errors
@@ -126,7 +126,7 @@ def store_time_mapping_safely(
         dict: Result containing success status and details
     """
     # Set default values to avoid errors
-    if not uuid:
+    if not schedule_uuid:
         uuid = "default_uuid"
     
     if not time_unit_map:
@@ -156,7 +156,7 @@ def store_time_mapping_safely(
     # Try to perform the upsert operation
     try:
         result = mongo.db.mapping_config.update_one(
-            {"uuid": uuid}, update_doc, upsert=True
+            {"schedule_uuid": schedule_uuid}, update_doc, upsert=True
         )
 
         return {


### PR DESCRIPTION
**Fixed time block manipulation and storage into db**
- Time blocks are now created when schedule needs to be generated based on scheduling period
- Time block is tagged to a specific `schedule_uuid` as each generated schedule may be of different scheduling periods

**Storing of schedule to MongoDB**
- Added functionality to store schedule generated to mongodb
- Each schedule has a unique id `schedule_uuid`

**Retrieval of schedules from MongoDB**
- Added api GET REQUEST to retrieve all generated schedules or retrieval of specific/multiple schedules by UUID through request.args